### PR TITLE
Self-closing <br/> in getContent() calls

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -191,7 +191,7 @@ define([
 
   Scribe.prototype.getContent = function () {
     // Remove bogus BR element for Firefox — see explanation in BR mode files.
-    return this._htmlFormatterFactory.formatForExport(this.getHTML().replace(/<br>$/, ''));
+    return this._htmlFormatterFactory.formatForExport(this.getHTML().replace(/<br>$/, '').replace(/<br>/g, '<br/>'));
   };
 
   Scribe.prototype.getTextContent = function () {


### PR DESCRIPTION
In support of max-length-based Scribe rich text truncation, we need to ensure that `<br/>` tags in `getContent()` output are self-closing.