### PR TITLE
Allow consecutive whitespace characters

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -115,8 +115,7 @@ define([
 
     // Formatters
     var defaultFormatters = Immutable.List.of(
-      escapeHtmlCharactersFormatter,
-      replaceNbspCharsFormatter
+      escapeHtmlCharactersFormatter
     );
 
 


### PR DESCRIPTION
A companion to https://github.com/4ormat/4ormat/pull/9856 which patches Scribe to allow consecutive spaces. It [passed QA nicely](https://app.asana.com/0/858352780261030/1151599763113610/f) so I feel good about merging!